### PR TITLE
Depth map colorizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,10 @@ add_executable(uvc_ros_driver_node
 	src/nodes/uvc_ros_driver_node.cpp
 )
 
+add_executable(depth_map_colorizer
+	src/nodes/depth_map_colorizer.cpp
+)
+
 ## Add cmake target dependencies of the executable
 ## same as for the library above
 # add_dependencies(uvc_ros_driver_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
@@ -167,6 +171,10 @@ add_executable(uvc_ros_driver_node
 ## Specify libraries to link a library or executable target against
 target_link_libraries(uvc_ros_driver_node
   uvc_ros_driver
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(depth_map_colorizer
   ${catkin_LIBRARIES}
 )
 

--- a/launch/uvc_ros_driver.launch
+++ b/launch/uvc_ros_driver.launch
@@ -15,6 +15,7 @@
   <arg name="cameraConfig" default="1" />
   <!-- calibration file in folder calib -->
   <arg name="cameraConfigFile" default="/media/camera/calibration.yaml" />
+  <arg name="depthMapColorizer" default="false" />
 
   <!-- camera node -->
   <node pkg="uvc_ros_driver" name="uvc_camera" type="uvc_ros_driver_node" output="screen">
@@ -29,5 +30,7 @@
     <rosparam command="load" file="$(find uvc_ros_driver)/params/homography_mapping.yaml" />
   </node>
 
-  <node pkg="uvc_ros_driver" name="depth_map_colorizer" type="depth_map_colorizer" output="screen" />
+  <group if="$(arg depthMapColorizer)">
+    <node pkg="uvc_ros_driver" name="depth_map_colorizer" type="depth_map_colorizer" output="screen" />
+  </group>
 </launch>

--- a/launch/uvc_ros_driver.launch
+++ b/launch/uvc_ros_driver.launch
@@ -29,4 +29,5 @@
     <rosparam command="load" file="$(find uvc_ros_driver)/params/homography_mapping.yaml" />
   </node>
 
+  <node pkg="uvc_ros_driver" name="depth_map_colorizer" type="depth_map_colorizer" output="screen" />
 </launch>

--- a/src/nodes/depth_map_colorizer.cpp
+++ b/src/nodes/depth_map_colorizer.cpp
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
 		}
 	} 
 
-	// Reserve space such that the publishers-vector doesn't move elements in memory
+	// Reserve space so the publishers-vector doesn't move elements in memory
 	int n = depth_topics.size();
 	std::vector<DepthMapPublisher> publishers;
 	publishers.reserve(n);

--- a/src/nodes/depth_map_colorizer.cpp
+++ b/src/nodes/depth_map_colorizer.cpp
@@ -1,0 +1,153 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2015-2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/*
+ * depth_map_colorizer.cpp
+ *
+ *  Created on: Jun 20, 2017
+ *      Author: Vilhjalmur
+ *
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <opencv2/core/core.hpp>
+
+#include <ros/ros.h>
+#include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/Image.h>
+
+int MIN_DEPTH = 8;
+int MAX_DEPTH = 255;
+
+class DepthMapPublisher {
+  public:
+	DepthMapPublisher() {} 
+	DepthMapPublisher(ros::NodeHandle &nh, std::string topic_name) 
+		: topic_name(topic_name)
+	{
+		publisher = nh.advertise<sensor_msgs::Image>(topic_name + "_color", 1);
+		subscriber = nh.subscribe(topic_name, 
+  						 1, 
+  						 &DepthMapPublisher::publishWithColor, 
+  						 this);
+	}
+
+	// Publish a colorized version of msg
+	void publishWithColor(const sensor_msgs::ImageConstPtr& msg) 
+	{
+		// std::cout << topic_name << std::endl;
+		cv_bridge::CvImagePtr disparity = cv_bridge::toCvCopy(*msg, "mono8");
+		colorizeDepth(disparity->image);
+		cv_bridge::CvImage out_msg;
+		out_msg.header = msg->header;
+		out_msg.encoding = "rgb8";
+		out_msg.image = colored_mat;
+	  	publisher.publish(out_msg.toImageMsg());
+	}
+
+	// Update colored_mat
+	void colorizeDepth(const cv::Mat &gray) {
+		if (gray.size() != colored_mat.size()) {
+	  		colored_mat.create(gray.size(), CV_8UC3);
+		}
+		for (int y = 0; y < gray.rows; y++) {
+			for (int x = 0; x < gray.cols; x++) {
+				colored_mat.at<cv::Point3_<unsigned char> >(y, x) = 
+					spectralColor(gray.at<unsigned char>(y, x));
+			}
+		}
+	}
+
+	// Returns a spectral color between blue (hue=0) and red (hue=255)
+	cv::Point3_<unsigned char> spectralColor(int hue) {
+		if (hue < MIN_DEPTH) {
+			// No depth information
+			return cv::Point3_<unsigned char>(0,0,0); 
+		}
+
+		// Crude approximation of spectral colors
+		hue = std::min(hue, MAX_DEPTH);
+		unsigned char r = std::max(0, 2*hue  - MAX_DEPTH);
+		unsigned char g = MAX_DEPTH - 2 * std::abs(hue - MAX_DEPTH/2);
+		unsigned char b = std::max(0, MAX_DEPTH - 2*hue);
+		return cv::Point3_<unsigned char>(r,g,b);
+	}
+
+	// Fields
+	ros::Publisher publisher;
+	ros::Subscriber subscriber;
+	std::string topic_name;
+	cv::Mat colored_mat;
+};
+
+
+// Returns true if topic is a depth map
+bool isDepthMapPublisher(std::string topic_name) {
+	return topic_name.find('image_depth') != std::string::npos;
+}
+
+
+int main(int argc, char **argv)
+{
+	// Create node
+	ros::init(argc, argv, "depth_map_colorizer");
+	ros::NodeHandle nh("~");
+
+	// Get topic Names
+	ros::master::V_TopicInfo topic_infos;
+	ros::master::getTopics(topic_infos);
+
+	// Filter depth-map topics
+	std::vector<std::string> depth_topics;
+	for (auto topic : topic_infos) {
+		if (isDepthMapPublisher(topic.name)) {
+			depth_topics.push_back(topic.name);
+		}
+	} 
+
+	// Reserve space such that the publishers-vector doesn't move elements in memory
+	int n = depth_topics.size();
+	std::vector<DepthMapPublisher> publishers;
+	publishers.reserve(n);
+
+	// Create publishers and matching subscribers
+	for (int i=0; i < n; ++i) {
+		std::string topic_name = depth_topics[i];
+  		publishers.emplace_back(nh, topic_name);
+	}
+
+	ros::spin();
+	return 0;
+}


### PR DESCRIPTION
A node which subscribes to gray-scale depth-images and republishes them with color.
It makes it easier to distinguish between different depths and pixels without depths. 